### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # SolvLoRA-GPR
-Apply gpt-oss for sloving regression task for predicting chemical compounds properties
+Apply gpt-oss for solving regression tasks predicting chemical compound properties


### PR DESCRIPTION
## Summary
- fix typo in README regarding regression task description

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d741df4a0832fbf27c8d73ec59ad2